### PR TITLE
Gauge: support void state

### DIFF
--- a/src/Gauge.zig
+++ b/src/Gauge.zig
@@ -40,7 +40,7 @@ pub fn Gauge(comptime StateType: type, comptime Return: type) type {
         pub fn get(self: *Self) Return {
             const TypeInfo = @typeInfo(StateType);
             switch (TypeInfo) {
-                .Pointer => {
+                .Pointer, .Void => {
                     return self.callFn(self.state);
                 },
                 .Optional => {


### PR DESCRIPTION
# Description

Allows making a Guage with an internal state of type `void`. this is useful when for instance exposing global data that does not requiring tracking an internal reference to return the needed value

# Checklist

- [ ] I added tests for my changes and they pass
