### PR TITLE
feat: Upgrade to Zig 0.13.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: master
+          version: 0.13.0
       - run: zig fmt --check *.zig src/*.zig
 
   build:
@@ -31,7 +31,7 @@ jobs:
           submodules: true
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: master
+          version: 0.13.0
 
       - name: Build examples
         run: zig build run-example-basic

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 zig-*
+.zig-cache
 .zigmod
 deps.zig

--- a/build.zig
+++ b/build.zig
@@ -1,26 +1,26 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
     const lib = b.addStaticLibrary(.{
         .name = "zig-prometheus",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
     b.installArtifact(lib);
     const main_tests = b.addTest(.{
         .name = "main",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
     const run_main_tests = b.addRunArtifact(main_tests);
 
     const module = b.addModule("prometheus", .{
-        .source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
     });
 
     const examples = &[_][]const u8{
@@ -30,11 +30,11 @@ pub fn build(b: *std.build.Builder) void {
     inline for (examples) |name| {
         var exe = b.addExecutable(.{
             .name = "example-" ++ name,
-            .root_source_file = .{ .path = "examples/" ++ name ++ "/main.zig" },
+            .root_source_file = b.path("examples/" ++ name ++ "/main.zig"),
             .target = target,
             .optimize = optimize,
         });
-        exe.addModule("prometheus", module);
+        exe.root_module.addImport("prometheus", module);
         b.installArtifact(exe);
 
         const run_cmd = b.addRunArtifact(exe);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,4 +1,5 @@
 .{
     .name = "prometheus",
     .version = "0.0.1",
+    .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,12 @@
 .{
     .name = "prometheus",
     .version = "0.0.1",
-    .paths = .{""},
+    .paths = .{
+        "examples",
+        "src",
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
 }

--- a/examples/basic/main.zig
+++ b/examples/basic/main.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 const prometheus = @import("prometheus");
 
-fn getRandomString(allocator: std.mem.Allocator, random: std.rand.Random, n: usize) ![]const u8 {
+fn getRandomString(allocator: std.mem.Allocator, random: std.Random, n: usize) ![]const u8 {
     const alphabet = "abcdefghijklmnopqrstuvwxyz";
 
     const items = try allocator.alloc(u8, n);
@@ -18,7 +18,7 @@ pub fn main() anyerror!void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     const allocator = arena.allocator();
 
-    var prng = std.rand.DefaultPrng.init(@bitCast(std.time.milliTimestamp()));
+    var prng = std.Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp()));
     const random = prng.random();
 
     // Initialize a registry
@@ -41,7 +41,7 @@ pub fn main() anyerror!void {
     // Get some gauges sharing the same state.
     {
         const State = struct {
-            random: std.rand.Random,
+            random: std.Random,
         };
         var state = State{ .random = random };
 

--- a/src/Counter.zig
+++ b/src/Counter.zig
@@ -20,11 +20,11 @@ pub fn init(allocator: mem.Allocator) !*Self {
 }
 
 pub fn inc(self: *Self) void {
-    _ = self.value.fetchAdd(1, .SeqCst);
+    _ = self.value.fetchAdd(1, .seq_cst);
 }
 
 pub fn dec(self: *Self) void {
-    _ = self.value.fetchSub(1, .SeqCst);
+    _ = self.value.fetchSub(1, .seq_cst);
 }
 
 pub fn add(self: *Self, value: anytype) void {
@@ -33,11 +33,11 @@ pub fn add(self: *Self, value: anytype) void {
         else => @compileError("can't add a non-number"),
     }
 
-    _ = self.value.fetchAdd(@intCast(value), .SeqCst);
+    _ = self.value.fetchAdd(@intCast(value), .seq_cst);
 }
 
 pub fn get(self: *const Self) u64 {
-    return self.value.load(.SeqCst);
+    return self.value.load(.seq_cst);
 }
 
 pub fn set(self: *Self, value: anytype) void {
@@ -46,13 +46,13 @@ pub fn set(self: *Self, value: anytype) void {
         else => @compileError("can't set a non-number"),
     }
 
-    _ = self.value.store(@intCast(value), .SeqCst);
+    _ = self.value.store(@intCast(value), .seq_cst);
 }
 
 fn getResult(metric: *Metric, allocator: mem.Allocator) Metric.Error!Metric.Result {
     _ = allocator;
 
-    const self = @fieldParentPtr(Self, "metric", metric);
+    const self: *Self = @fieldParentPtr("metric", metric);
 
     return Metric.Result{ .counter = self.get() };
 }

--- a/src/Gauge.zig
+++ b/src/Gauge.zig
@@ -58,7 +58,7 @@ pub fn Gauge(comptime StateType: type, comptime Return: type) type {
         fn getResult(metric: *Metric, allocator: mem.Allocator) Metric.Error!Metric.Result {
             _ = allocator;
 
-            const self = @fieldParentPtr(Self, "metric", metric);
+            const self: *Self = @fieldParentPtr("metric", metric);
 
             return switch (Return) {
                 f64 => Metric.Result{ .gauge = self.get() },

--- a/src/main.zig
+++ b/src/main.zig
@@ -77,7 +77,7 @@ pub fn Registry(comptime options: RegistryOptions) type {
                 gop.value_ptr.* = &real_metric.metric;
             }
 
-            return @fieldParentPtr(Counter, "metric", gop.value_ptr.*);
+            return @fieldParentPtr("metric", gop.value_ptr.*);
         }
 
         pub fn getOrCreateHistogram(self: *Self, name: []const u8) GetMetricError!*Histogram {
@@ -97,7 +97,7 @@ pub fn Registry(comptime options: RegistryOptions) type {
                 gop.value_ptr.* = &real_metric.metric;
             }
 
-            return @fieldParentPtr(Histogram, "metric", gop.value_ptr.*);
+            return @fieldParentPtr("metric", gop.value_ptr.*);
         }
 
         pub fn getOrCreateGauge(
@@ -122,7 +122,7 @@ pub fn Registry(comptime options: RegistryOptions) type {
                 gop.value_ptr.* = &real_metric.metric;
             }
 
-            return @fieldParentPtr(Gauge(@TypeOf(state), f64), "metric", gop.value_ptr.*);
+            return @fieldParentPtr("metric", gop.value_ptr.*);
         }
 
         pub fn getOrCreateGaugeInt(
@@ -147,7 +147,7 @@ pub fn Registry(comptime options: RegistryOptions) type {
                 gop.value_ptr.* = &real_metric.metric;
             }
 
-            return @fieldParentPtr(Gauge(@TypeOf(state), u64), "metric", gop.value_ptr.*);
+            return @fieldParentPtr("metric", gop.value_ptr.*);
         }
 
         pub fn write(self: *Self, allocator: mem.Allocator, writer: anytype) !void {
@@ -217,9 +217,9 @@ test "registry write" {
 
     const exp1 =
         \\http_conn_pool_size 4.000000
-        \\http_request_size_bucket{vmrange="1.292e+02...1.468e+02"} 1
-        \\http_request_size_bucket{vmrange="4.642e+02...5.275e+02"} 1
-        \\http_request_size_bucket{vmrange="1.136e+03...1.292e+03"} 1
+        \\http_request_size_bucket{vmrange="1.292e2...1.468e2"} 1
+        \\http_request_size_bucket{vmrange="4.642e2...5.275e2"} 1
+        \\http_request_size_bucket{vmrange="1.136e3...1.292e3"} 1
         \\http_request_size_sum 1870.360000
         \\http_request_size_count 3
         \\http_requests 2
@@ -228,9 +228,9 @@ test "registry write" {
 
     const exp2 =
         \\http_conn_pool_size{route="/api/v2/users"} 4.000000
-        \\http_request_size_bucket{route="/api/v2/users",vmrange="1.292e+02...1.468e+02"} 1
-        \\http_request_size_bucket{route="/api/v2/users",vmrange="4.642e+02...5.275e+02"} 1
-        \\http_request_size_bucket{route="/api/v2/users",vmrange="1.136e+03...1.292e+03"} 1
+        \\http_request_size_bucket{route="/api/v2/users",vmrange="1.292e2...1.468e2"} 1
+        \\http_request_size_bucket{route="/api/v2/users",vmrange="4.642e2...5.275e2"} 1
+        \\http_request_size_bucket{route="/api/v2/users",vmrange="1.136e3...1.292e3"} 1
         \\http_request_size_sum{route="/api/v2/users"} 1870.360000
         \\http_request_size_count{route="/api/v2/users"} 3
         \\http_requests{route="/api/v2/users"} 2

--- a/src/metric.zig
+++ b/src/metric.zig
@@ -19,9 +19,8 @@ pub const HistogramResult = struct {
             if (@as(f64, @floatFromInt(as_int)) == self.value) {
                 try fmt.formatInt(as_int, 10, .lower, options, writer);
             } else {
-                // this buffer should be enough to display all decimal places of a decimal f64 number.
-                var buf: [512]u8 = undefined;
                 // FIXME: Use the writer directly once the formatFloat API accepts a writer
+                var buf: [fmt.format_float.bufferSize(.decimal, @TypeOf(self.value))]u8 = undefined;
                 const formatted = try fmt.formatFloat(&buf, self.value, .{
                     .mode = .decimal,
                     .precision = options.precision,


### PR DESCRIPTION
# Description

This pull request upgrades the code to Zig 0.13.0.
I know this project is not targeted to any Zig releases, but I prepared a checkpoint for users who wants to pin at an (un)stable release of Zig.
Upgrading to 0.14.0-dev as of today will be achieved in another pull request (#15).

CI run: https://github.com/siketyan/zig-prometheus/actions/runs/12587047798
